### PR TITLE
Fix broken relation icons on term details pages

### DIFF
--- a/templates/html/bs3/common/term_details_re_row.tmpl
+++ b/templates/html/bs3/common/term_details_re_row.tmpl
@@ -13,13 +13,21 @@
   <td>
     <span class="nowrap">
       [% IF subject_chunk.inferred_p %]
+      [% IF subject_chunk.rel == "is_a" OR subject_chunk.rel == "part_of" OR subject_chunk.rel == "regulates" OR subject_chunk.rel == "negatively_regulates" OR subject_chunk.rel == "positively_regulates" OR subject_chunk.rel == "has_part" OR subject_chunk.rel == "occurs_in" OR subject_chunk.rel == "capable_of" OR subject_chunk.rel == "develops_from" OR subject_chunk.rel == "related_to" %]
       <img src="[% image_dir _ "/" _ subject_chunk.rel _ ".gif" %]"
 	   alt="[Inferred [% subject_chunk.rel %] relation]"
 	   title="Inferred [% subject_chunk.rel %] relation" />&nbsp;[% subject_chunk.rel %]&nbsp;(inferred)
       [% ELSE %]
+      [% subject_chunk.rel %]&nbsp;(inferred)
+      [% END %]
+      [% ELSE %]
+      [% IF subject_chunk.rel == "is_a" OR subject_chunk.rel == "part_of" OR subject_chunk.rel == "regulates" OR subject_chunk.rel == "negatively_regulates" OR subject_chunk.rel == "positively_regulates" OR subject_chunk.rel == "has_part" OR subject_chunk.rel == "occurs_in" OR subject_chunk.rel == "capable_of" OR subject_chunk.rel == "develops_from" OR subject_chunk.rel == "related_to" %]
       <img src="[% image_dir _ "/" _ subject_chunk.rel _ ".gif" %]"
 	   alt="[[% subject_chunk.rel %] relation]"
 	   title="[% subject_chunk.rel %] relation" />&nbsp;[% subject_chunk.rel %]&nbsp;
+      [% ELSE %]
+      [% subject_chunk.rel %]&nbsp;
+      [% END %]
       [% END %]
     </span>
   </td>
@@ -33,13 +41,21 @@
   <td>
     <span class="nowrap">
       [% IF object_chunk.inferred_p %]
+      [% IF object_chunk.rel == "is_a" OR object_chunk.rel == "part_of" OR object_chunk.rel == "regulates" OR object_chunk.rel == "negatively_regulates" OR object_chunk.rel == "positively_regulates" OR object_chunk.rel == "has_part" OR object_chunk.rel == "occurs_in" OR object_chunk.rel == "capable_of" OR object_chunk.rel == "develops_from" OR object_chunk.rel == "related_to" %]
       <img src="[% image_dir _ "/" _ object_chunk.rel _ ".gif" %]"
 	   alt="[Inferred [% object_chunk.rel %] relation]"
 	   title="Inferred [% object_chunk.rel %] relation" />&nbsp;[% object_chunk.rel %]&nbsp;(inferred)
       [% ELSE %]
+      [% object_chunk.rel %]&nbsp;(inferred)
+      [% END %]
+      [% ELSE %]
+      [% IF object_chunk.rel == "is_a" OR object_chunk.rel == "part_of" OR object_chunk.rel == "regulates" OR object_chunk.rel == "negatively_regulates" OR object_chunk.rel == "positively_regulates" OR object_chunk.rel == "has_part" OR object_chunk.rel == "occurs_in" OR object_chunk.rel == "capable_of" OR object_chunk.rel == "develops_from" OR object_chunk.rel == "related_to" %]
       <img src="[% image_dir _ "/" _ object_chunk.rel _ ".gif" %]"
 	   alt="[[% object_chunk.rel %] relation]"
 	   title="[% object_chunk.rel %] relation" />&nbsp;[% object_chunk.rel %]&nbsp;
+      [% ELSE %]
+      [% object_chunk.rel %]&nbsp;
+      [% END %]
       [% END %]
     </span>
   </td>

--- a/test-app/behave/02_core_basic.feature
+++ b/test-app/behave/02_core_basic.feature
@@ -32,3 +32,10 @@ Feature: AmiGO core data is okay
     Given I go to page "/amigo/gene_product/UniProtKB:P35222"
      then the class "page-header" should contain "Catenin beta-1"
      and the class "amigo-detail-info" should contain "Catenin beta-1"
+
+ ## Fix for broken relation icons
+ @go
+ Scenario: term details page shows relations without broken icons
+    Given I go to page "/amigo/term/GO:0001508"
+     then the title should contain "action potential"
+     and the page should not contain broken images

--- a/test-app/behave/steps/basic.py
+++ b/test-app/behave/steps/basic.py
@@ -3,6 +3,7 @@
 ####
 
 from behave import *
+from urllib.parse import urlparse
 
 ## The basic and critical "go to page".
 @given('I go to page "{page}"')
@@ -30,6 +31,10 @@ def step_impl(context, title):
     #print(context.browser.title)
     #print(title)
     assert context.browser.title == title
+
+@then('the title should contain "{text}"')
+def step_impl(context, text):
+    assert text in context.browser.title
 
 @then('the class "{clss}" should contain "{text}"')
 def step_impl(context, clss, text):
@@ -108,3 +113,24 @@ def step_impl(context, tabname, text):
             # print(tab_area_elt.text)
             assert tab_area_elt and tab_area_elt.text.rfind(text) != -1
     assert found_tab
+
+## Check for broken images on the page
+@then('the page should not contain broken images')
+def step_impl(context):
+    from selenium.webdriver.common.by import By
+    
+    # Get all images on the page
+    images = context.browser.find_elements(By.TAG_NAME, 'img')
+    
+    # Check each image
+    broken_images = []
+    for img in images:
+        # Check if the image is displayed
+        if not img.is_displayed():
+            # Get image details for logging
+            img_src = img.get_attribute('src')
+            img_alt = img.get_attribute('alt')
+            broken_images.append(f"Broken image: src={img_src}, alt={img_alt}")
+    
+    # Assert that no broken images were found
+    assert len(broken_images) == 0, f"Found {len(broken_images)} broken images: {broken_images}"


### PR DESCRIPTION
## Summary
- Fix broken relation icons on term details pages by only showing icon images for known relation types
- Add fallback to text-only display for relations without corresponding image files
- Add Behave test to verify term detail pages don't display broken images

## Test plan
1. Visit a term details page with non-standard relation types (e.g., https://amigo.geneontology.org/amigo/term/GO:0001508)
2. Verify that relations like "RO:0002212" appear as text without broken icons
3. Verify that standard relations (is_a, part_of, etc.) still show their icons correctly
4. Run the new Behave test scenario added to the test suite